### PR TITLE
Allow ranges of IP addresses

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@
 
 const SEARCH_RESULT_FORMAT = {
     IP_ADDRESS: 'ipaddress',
+    IP_RANGE: 'iprange',
     CIDR: 'cidr'
 };
 
@@ -77,6 +78,8 @@ async function search(/*int*/ asn, /*enum (String)*/ resultFormat = SEARCH_RESUL
                 let mask = 32;
                 for (let networkSize = network.end - network.start + 1; networkSize > 1; networkSize>>=1, mask-=1);
                 yield `${_ipInt32ToDotDecimal(network.start)}/${mask}`;
+            } else if(resultFormat == SEARCH_RESULT_FORMAT.IP_RANGE) {
+                yield `${_ipInt32ToDotDecimal(network.start)}-${_ipInt32ToDotDecimal(network.end)}`;
             } else {
                 throw new Error('Invalid result format');
             }


### PR DESCRIPTION
This is not tested at all!

By being able to ban ranges of IP addresses instead of assuming each range is a CIDR, we can be more accurate: we will ban all IPs in the range and not just ones that are pretty close, and we won't ban any IP out of the range, even if it would be in a CIDR of comparable size. 